### PR TITLE
fix: Remove flash of loading page

### DIFF
--- a/src/routes/word.tsx
+++ b/src/routes/word.tsx
@@ -1,14 +1,27 @@
-import { Suspense } from "react";
+import { Suspense, useDeferredValue, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 
 import { DictEntries } from "components/DictEntries";
 
+function Fallback() {
+  const pause = 100;
+  const [isShowing, setIsShowing] = useState(false);
+  useEffect(() => {
+    setTimeout(() => {
+      setIsShowing(true);
+    }, pause);
+  }, []);
+  return isShowing ? <p>Loading dictionary...</p> : null;
+}
+
 export function Word() {
   let { word } = useParams();
   if (!word) word = "";
+
+  const deferredWord = useDeferredValue(word);
   return (
-    <Suspense fallback={<p>Loading dictionary...</p>}>
-      <DictEntries word={word} />
+    <Suspense fallback={Fallback()}>
+      <DictEntries word={deferredWord} />
     </Suspense>
   );
 }


### PR DESCRIPTION
- Use deferredValue to suppress fallback page when showing another page.
- The fallback page shows only after a timeout of 100s, so the fallback do not show during the first rendering of component Word() if dictioary is already loaded.