### PR TITLE
fix: Change float: inline-end to float: right

### DIFF
--- a/src/components/DarkModeToggle.css
+++ b/src/components/DarkModeToggle.css
@@ -1,5 +1,5 @@
 .dark-mode-toggle {
-  float: inline-end;
+  float: right;
   height: 40px;
   width: 40px;
   border: none;


### PR DESCRIPTION
The style float: inline-end is only introduced in Chrome 118, so browser support may be bad.