### PR TITLE
feat: Add handling of tab title

### DIFF
--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -11,6 +11,7 @@ describe("Hello Dict app", () => {
     // The dictionary entries should load with an entry with the word.
     // Comparison is not case-sensitive because GCIDE capitalizes headwords.
     cy.get(".dict-item").contains(/\btest\b/i);
+    cy.title().contains(/\btest\b/i);
   });
 
   it("Type in a word and press the button should load the dictionary entries.", () => {
@@ -22,6 +23,7 @@ describe("Hello Dict app", () => {
     // The dictionary entries should load with an entry with the word.
     // Comparison is not case-sensitive because GCIDE capitalizes headwords.
     cy.get(".dict-item").contains(/\btest\b/i);
+    cy.title().contains(/\btest\b/i);
   });
 
   it("Visit #/word/:word should load the dictionary entries. A second visit should not reload dictionary data.", () => {
@@ -30,10 +32,12 @@ describe("Hello Dict app", () => {
     // The dictionary entries should load with an entry with the word.
     // Comparison is not case-sensitive because GCIDE capitalizes headwords.
     cy.get(".dict-item").contains(/\btest\b/i);
+    cy.title().contains(/\btest\b/i);
 
     cy.visit("#/word/study");
     // The second visit should load instantiously.
     cy.get(".dict-item").contains(/\bstudy\b/i, { timeout: 100 });
+    cy.title().contains(/\bstudy\b/i);
   });
 
   it("Search with an empty textbox should navigate to somewhere other than #/word/ .", () => {
@@ -42,5 +46,6 @@ describe("Hello Dict app", () => {
     // The browser should navigate to a new URL (no "about").
     cy.hash().should("not.include", "about");
     cy.hash().should("not.include", "word");
+    cy.title().should("not.include", "- Hello");
   });
 });

--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -11,7 +11,7 @@ describe("Hello Dict app", () => {
     // The dictionary entries should load with an entry with the word.
     // Comparison is not case-sensitive because GCIDE capitalizes headwords.
     cy.get(".dict-item").contains(/\btest\b/i);
-    cy.title().contains(/\btest\b/i);
+    cy.title().should("include", "test");
   });
 
   it("Type in a word and press the button should load the dictionary entries.", () => {
@@ -23,7 +23,7 @@ describe("Hello Dict app", () => {
     // The dictionary entries should load with an entry with the word.
     // Comparison is not case-sensitive because GCIDE capitalizes headwords.
     cy.get(".dict-item").contains(/\btest\b/i);
-    cy.title().contains(/\btest\b/i);
+    cy.title().should("include", "test");
   });
 
   it("Visit #/word/:word should load the dictionary entries. A second visit should not reload dictionary data.", () => {
@@ -32,12 +32,13 @@ describe("Hello Dict app", () => {
     // The dictionary entries should load with an entry with the word.
     // Comparison is not case-sensitive because GCIDE capitalizes headwords.
     cy.get(".dict-item").contains(/\btest\b/i);
-    cy.title().contains(/\btest\b/i);
+    cy.title().should("include", "test");
 
     cy.visit("#/word/study");
     // The second visit should load instantiously.
     cy.get(".dict-item").contains(/\bstudy\b/i, { timeout: 100 });
-    cy.title().contains(/\bstudy\b/i);
+    cy.title().should("not.include", "test");
+    cy.title().should("include", "study");
   });
 
   it("Search with an empty textbox should navigate to somewhere other than #/word/ .", () => {

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fira+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
+    <title>Hello Dict - free dictionary</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/routes/about.tsx
+++ b/src/routes/about.tsx
@@ -1,4 +1,7 @@
+import { setTitleWithPrefix } from "utils/setTitle";
+
 export function About() {
+  setTitleWithPrefix();
   return (
     <>
       <h1>Hello Dict</h1>

--- a/src/routes/word.tsx
+++ b/src/routes/word.tsx
@@ -3,6 +3,8 @@ import { useParams } from "react-router-dom";
 
 import { DictEntries } from "components/DictEntries";
 
+import { setTitleWithPrefix } from "utils/setTitle";
+
 function Fallback() {
   const pause = 100;
   const [isShowing, setIsShowing] = useState(false);
@@ -19,6 +21,7 @@ export function Word() {
   if (!word) word = "";
 
   const deferredWord = useDeferredValue(word);
+  setTitleWithPrefix(deferredWord);
   return (
     <Suspense fallback={Fallback()}>
       <DictEntries word={deferredWord} />

--- a/src/utils/setTitle.ts
+++ b/src/utils/setTitle.ts
@@ -1,0 +1,6 @@
+export function setTitleWithPrefix(prefix?: string): void {
+  const newTitle = prefix
+    ? `${prefix} - Hello Dict`
+    : "Hello Dict - free dictionary";
+  if (newTitle !== document.title) document.title = newTitle;
+}


### PR DESCRIPTION
The new document titles are as follows:
- for dictionary lookup: "[word] - Hello Dict" (without brackets)
- for other pages: "Hello Dict - free dictionary"

Also fixed the regression removing the title from index.html