### PR TITLE
fix: Change light mode link color to pass WCAG AA

### DIFF
--- a/src/index.less
+++ b/src/index.less
@@ -16,7 +16,7 @@
 .light-mode() {
   --fg-color: #213547;
   --bg-color: #f4f4f4;
-  --link-color: #ad5f00;
+  --link-color: #a85d00;
   --link-hover-color: #804600;
   --form-field-bg-color: white;
   --form-field-border-color: #c0c0c0;


### PR DESCRIPTION
Contrast ratio is increased to 4.51, where the passing ratio is 4.50.